### PR TITLE
fix(ci): exempt dependabot from ai disclosure gate

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -31,6 +31,17 @@ jobs:
               return;
             }
 
+            const prAuthor = pr.user?.login || '';
+            const isDependabotPr =
+              prAuthor === 'dependabot[bot]' ||
+              prAuthor === 'app/dependabot' ||
+              (pr.user?.type === 'Bot' && prAuthor.toLowerCase().includes('dependabot'));
+
+            if (isDependabotPr) {
+              core.info(`Skipping AI disclosure gate for Dependabot PR authored by ${prAuthor}.`);
+              return;
+            }
+
             const body = pr.body || '';
             const disclosurePattern = /-\s*\[( |x|X)\]\s*AI-assisted changes are included in this PR/;
             const aiAssistedPattern = /-\s*\[(x|X)\]\s*AI-assisted changes are included in this PR/;


### PR DESCRIPTION
## Summary
- skip the AI disclosure workflow for Dependabot-authored PRs
- keep the existing disclosure and human-approval checks for human-authored AI-assisted PRs
- unblock low-risk dependency and workflow update PRs from policy deadlock

## Security Review
- no runtime code paths changed
- no new dependencies added
- branch protection and required CI checks remain unchanged

- [x] AI-assisted changes are included in this PR
