### PR TITLE
docs: fix repo-relative links in README

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -10,7 +10,7 @@ This repository is maintained as proprietary TrustSignal software and documentat
 
 ## Repository Consistency Rules
 
-- Root ownership and license notices must remain consistent with the proprietary repository license in [`LICENSE`](/Users/christopher/Projects/TrustSignal/LICENSE).
+- Root ownership and license notices must remain consistent with the proprietary repository license in [`LICENSE`](LICENSE).
 - File-level license headers that conflict with the repository ownership position must be reviewed deliberately and documented before they are included in any ownership or registration claim.
 - If a contribution was created with material AI assistance, external templates, copied snippets, contractor input, or third-party source material, that provenance must be recorded before the file is treated as a registration candidate.
 
@@ -31,10 +31,10 @@ The following categories are excluded from the initial copyright registration ca
 
 ## Open License Decision
 
-- [`packages/contracts/contracts/AnchorRegistry.sol`](/Users/christopher/Projects/TrustSignal/packages/contracts/contracts/AnchorRegistry.sol) currently carries an `Apache-2.0` SPDX header.
+- [`packages/contracts/contracts/AnchorRegistry.sol`](packages/contracts/contracts/AnchorRegistry.sol) currently carries an `Apache-2.0` SPDX header.
 - That file must be treated as a deliberate license-decision item and excluded from the initial proprietary registration bundle until its licensing intent is explicitly resolved.
 
 ## Notices and Attribution
 
-- If you add third-party code or assets, include any required attribution or notice material in [`NOTICE`](/Users/christopher/Projects/TrustSignal/NOTICE) or in file-level notices as appropriate.
+- If you add third-party code or assets, include any required attribution or notice material in [`NOTICE`](NOTICE) or in file-level notices as appropriate.
 - Do not remove or alter third-party license notices without confirming the applicable license obligations.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Those risks matter in audit, compliance, partner-review, and trust-sensitive wor
 
 ## Verification Lifecycle
 
-The canonical lifecycle diagram and trust-boundary view are documented in [docs/verification-lifecycle.md](/Users/christopher/Projects/trustsignal/docs/verification-lifecycle.md).
+The canonical lifecycle diagram and trust-boundary view are documented in [docs/verification-lifecycle.md](docs/verification-lifecycle.md).
 
 TrustSignal accepts a verification request, returns verification signals, issues a signed verification receipt, and supports later verification against stored receipt state so downstream teams can detect artifact tampering, evidence provenance loss, or stale records during audit review.
 
@@ -47,17 +47,17 @@ It shows the full lifecycle in one run:
 4. later verification
 5. tampered artifact mismatch detection
 
-See [demo/README.md](/Users/christopher/Projects/trustsignal/demo/README.md).
+See [demo/README.md](demo/README.md).
 
 ## Integration Model
 
 Start here if you are evaluating the public verification lifecycle:
 
-- [Evaluator quickstart](/Users/christopher/Projects/trustsignal/docs/partner-eval/quickstart.md)
-- [API playground](/Users/christopher/Projects/trustsignal/docs/partner-eval/api-playground.md)
-- [OpenAPI contract](/Users/christopher/Projects/trustsignal/openapi.yaml)
-- [Postman collection](/Users/christopher/Projects/trustsignal/postman/TrustSignal.postman_collection.json)
-- [Postman local environment](/Users/christopher/Projects/trustsignal/postman/TrustSignal.local.postman_environment.json)
+- [Evaluator quickstart](docs/partner-eval/quickstart.md)
+- [API playground](docs/partner-eval/api-playground.md)
+- [OpenAPI contract](openapi.yaml)
+- [Postman collection](postman/TrustSignal.postman_collection.json)
+- [Postman local environment](postman/TrustSignal.local.postman_environment.json)
 
 Golden path:
 
@@ -191,12 +191,12 @@ Fail-closed defaults are part of the security posture. They are meant to prevent
 
 The public evaluation artifacts in this repo are:
 
-- [openapi.yaml](/Users/christopher/Projects/trustsignal/openapi.yaml)
-- [verification-request.json](/Users/christopher/Projects/trustsignal/examples/verification-request.json)
-- [verification-response.json](/Users/christopher/Projects/trustsignal/examples/verification-response.json)
-- [verification-receipt.json](/Users/christopher/Projects/trustsignal/examples/verification-receipt.json)
-- [verification-status.json](/Users/christopher/Projects/trustsignal/examples/verification-status.json)
-- [partner evaluation kit](/Users/christopher/Projects/trustsignal/docs/partner-eval/overview.md)
+- [openapi.yaml](openapi.yaml)
+- [verification-request.json](examples/verification-request.json)
+- [verification-response.json](examples/verification-response.json)
+- [verification-receipt.json](examples/verification-receipt.json)
+- [verification-status.json](examples/verification-status.json)
+- [partner evaluation kit](docs/partner-eval/overview.md)
 
 These artifacts document the public verification lifecycle only. They intentionally avoid proof internals, model outputs, circuit identifiers, signing infrastructure specifics, and internal service topology.
 
@@ -211,7 +211,7 @@ Public-facing security properties for this repository are:
 - explicit lifecycle boundaries for read, revoke, and provenance-state operations
 - fail-closed defaults where production trust assumptions are not satisfied
 
-See [docs/security-summary.md](/Users/christopher/Projects/trustsignal/docs/security-summary.md), [SECURITY_CHECKLIST.md](/Users/christopher/Projects/trustsignal/SECURITY_CHECKLIST.md), and [docs/SECURITY.md](/Users/christopher/Projects/trustsignal/docs/SECURITY.md) for the current public-safe security summary and repository guardrails.
+See [docs/security-summary.md](docs/security-summary.md), [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md), and [docs/SECURITY.md](docs/SECURITY.md) for the current public-safe security summary and repository guardrails.
 
 ## What TrustSignal Does Not Claim
 
@@ -225,7 +225,7 @@ TrustSignal does not provide:
 
 ## Current Repository Context
 
-DeedShield is the current application surface in this repository. The broader product framing remains TrustSignal as evidence integrity infrastructure and an integrity layer for existing workflows.
+TrustSignal is the canonical product and application surface in this repository. The current wedge remains property-record verification, with the platform framed as evidence integrity infrastructure for existing workflows.
 
 ## Newbie Difficulty Rating
 
@@ -261,10 +261,10 @@ npm run build
 
 ## Documentation Map
 
-- [docs/partner-eval/overview.md](/Users/christopher/Projects/trustsignal/docs/partner-eval/overview.md)
-- [docs/partner-eval/quickstart.md](/Users/christopher/Projects/trustsignal/docs/partner-eval/quickstart.md)
-- [docs/partner-eval/api-playground.md](/Users/christopher/Projects/trustsignal/docs/partner-eval/api-playground.md)
-- [wiki/What-is-TrustSignal.md](/Users/christopher/Projects/trustsignal/wiki/What-is-TrustSignal.md)
-- [wiki/API-Overview.md](/Users/christopher/Projects/trustsignal/wiki/API-Overview.md)
-- [wiki/Claims-Boundary.md](/Users/christopher/Projects/trustsignal/wiki/Claims-Boundary.md)
-- [wiki/Verification-Receipts.md](/Users/christopher/Projects/trustsignal/wiki/Verification-Receipts.md)
+- [docs/partner-eval/overview.md](docs/partner-eval/overview.md)
+- [docs/partner-eval/quickstart.md](docs/partner-eval/quickstart.md)
+- [docs/partner-eval/api-playground.md](docs/partner-eval/api-playground.md)
+- [wiki/What-is-TrustSignal.md](wiki/What-is-TrustSignal.md)
+- [wiki/API-Overview.md](wiki/API-Overview.md)
+- [wiki/Claims-Boundary.md](wiki/Claims-Boundary.md)
+- [wiki/Verification-Receipts.md](wiki/Verification-Receipts.md)

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ TrustSignal does not provide:
 
 ## Current Repository Context
 
-TrustSignal is the canonical product and application surface in this repository. The current wedge remains property-record verification, with the platform framed as evidence integrity infrastructure for existing workflows.
+TrustSignal is the core platform and canonical application surface shipped from this repository. DeedShield is the initial property-record verification wedge/module built on top of the TrustSignal platform for property-title and deed workflows. DeedShield-named docs, monitoring rules, and watcher services in this repo refer specifically to that property-record module and do not change that TrustSignal is the primary product and application surface exposed here.
 
 ## Newbie Difficulty Rating
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -31,8 +31,8 @@ npx tsx bench/run-bench.ts --scenario batch --batch-size 10
 
 The harness writes:
 
-- [latest.json](/Users/christopher/Projects/trustsignal/bench/results/latest.json)
-- [latest.md](/Users/christopher/Projects/trustsignal/bench/results/latest.md)
+- [latest.json](bench/results/latest.json)
+- [latest.md](bench/results/latest.md)
 
 The JSON contains raw timings plus aggregate metrics. The Markdown report is the public-safe evaluator summary for docs.
 
@@ -40,5 +40,5 @@ The JSON contains raw timings plus aggregate metrics. The Markdown report is the
 
 - The harness starts a temporary local PostgreSQL instance and tears it down after the run.
 - It targets the real local `/api/v1/*` evaluator routes through Fastify injection, so it exercises the same request validation, auth checks, persistence, receipt issuance, and later-verification logic used by the current evaluator path.
-- It uses local fixture artifacts from [bench/fixtures](/Users/christopher/Projects/trustsignal/bench/fixtures) to keep clean and tampered runs deterministic.
+- It uses local fixture artifacts from [bench/fixtures](bench/fixtures) to keep clean and tampered runs deterministic.
 - Current metrics are local benchmark snapshots, not production guarantees.

--- a/wiki/API-Overview.md
+++ b/wiki/API-Overview.md
@@ -17,7 +17,7 @@ Partners need a stable public contract that explains how TrustSignal fits into a
 
 ## Verification Lifecycle
 
-The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](/Users/christopher/Projects/trustsignal/docs/verification-lifecycle.md).
+The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](docs/verification-lifecycle.md).
 
 TrustSignal exposes a public verification lifecycle centered on signed verification receipts, verification signals, verifiable provenance metadata, and later verification.
 
@@ -25,16 +25,16 @@ TrustSignal exposes a public verification lifecycle centered on signed verificat
 
 Start with the local developer trial for the fastest lifecycle walkthrough:
 
-- [5-minute developer trial](/Users/christopher/Projects/trustsignal/demo/README.md)
+- [5-minute developer trial](demo/README.md)
 
 ## Integration Model
 
 Start here to try the public lifecycle:
 
-- [OpenAPI contract](/Users/christopher/Projects/trustsignal/openapi.yaml)
-- [Evaluator quickstart](/Users/christopher/Projects/trustsignal/docs/partner-eval/quickstart.md)
-- [API playground](/Users/christopher/Projects/trustsignal/docs/partner-eval/api-playground.md)
-- [Postman collection](/Users/christopher/Projects/trustsignal/postman/TrustSignal.postman_collection.json)
+- [OpenAPI contract](openapi.yaml)
+- [Evaluator quickstart](docs/partner-eval/quickstart.md)
+- [API playground](docs/partner-eval/api-playground.md)
+- [Postman collection](postman/TrustSignal.postman_collection.json)
 
 Golden path:
 
@@ -103,4 +103,4 @@ Integrators should expect these broad patterns:
 - `429` for rate limiting
 - `503` when a required dependency is unavailable
 
-The canonical public contract for the verification lifecycle is [openapi.yaml](/Users/christopher/Projects/trustsignal/openapi.yaml).
+The canonical public contract for the verification lifecycle is [openapi.yaml](openapi.yaml).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -21,7 +21,7 @@ High-loss environments create incentives for these attack paths because downstre
 
 ## Verification Lifecycle
 
-The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](/Users/christopher/Projects/trustsignal/docs/verification-lifecycle.md).
+The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](docs/verification-lifecycle.md).
 
 TrustSignal provides signed verification receipts, verification signals, verifiable provenance metadata, and later verification capability as an integrity layer for an existing system of record.
 
@@ -35,15 +35,15 @@ TrustSignal provides signed verification receipts, verification signals, verifia
 
 ## Demo
 
-- [5-minute developer trial](/Users/christopher/Projects/trustsignal/demo/README.md)
+- [5-minute developer trial](demo/README.md)
 
 ## Integration Model
 
 Use the evaluator docs when you want to see the verification lifecycle before production integration detail:
 
-- [Evaluator quickstart](/Users/christopher/Projects/trustsignal/docs/partner-eval/quickstart.md)
-- [API playground](/Users/christopher/Projects/trustsignal/docs/partner-eval/api-playground.md)
-- [OpenAPI contract](/Users/christopher/Projects/trustsignal/openapi.yaml)
+- [Evaluator quickstart](docs/partner-eval/quickstart.md)
+- [API playground](docs/partner-eval/api-playground.md)
+- [OpenAPI contract](openapi.yaml)
 
 ## Technical Details
 

--- a/wiki/Quick-Verification-Example.md
+++ b/wiki/Quick-Verification-Example.md
@@ -17,7 +17,7 @@ This example is for partner engineers who want the smallest realistic TrustSigna
 
 ## Verification Lifecycle
 
-The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](/Users/christopher/Projects/trustsignal/docs/verification-lifecycle.md).
+The canonical lifecycle diagram is documented in [docs/verification-lifecycle.md](docs/verification-lifecycle.md).
 
 This example uses the current integration-facing lifecycle to create a verification, return verification signals plus a signed verification receipt, store the receipt with the workflow record, and later verify stored receipt state during audit review.
 
@@ -25,10 +25,10 @@ This example uses the current integration-facing lifecycle to create a verificat
 
 Start here for the full evaluator path:
 
-- [Evaluator quickstart](/Users/christopher/Projects/trustsignal/docs/partner-eval/quickstart.md)
-- [API playground](/Users/christopher/Projects/trustsignal/docs/partner-eval/api-playground.md)
-- [OpenAPI contract](/Users/christopher/Projects/trustsignal/openapi.yaml)
-- [Postman collection](/Users/christopher/Projects/trustsignal/postman/TrustSignal.postman_collection.json)
+- [Evaluator quickstart](docs/partner-eval/quickstart.md)
+- [API playground](docs/partner-eval/api-playground.md)
+- [OpenAPI contract](openapi.yaml)
+- [Postman collection](postman/TrustSignal.postman_collection.json)
 
 ## Integration Model
 

--- a/wiki/What-is-TrustSignal.md
+++ b/wiki/What-is-TrustSignal.md
@@ -25,7 +25,7 @@ TrustSignal is evidence integrity infrastructure. It provides signed verificatio
 
 The fastest local evaluator path is the 5-minute developer trial:
 
-- [5-minute developer trial](/Users/christopher/Projects/trustsignal/demo/README.md)
+- [5-minute developer trial](demo/README.md)
 
 ## Integration
 


### PR DESCRIPTION
## Summary
- fix repo-relative links in `README.md` so GitHub renders repository paths correctly on the default branch
- remove machine-local absolute paths from public documentation links
- align the repository context wording in the README with the current TrustSignal positioning

## Security Review
- No code paths, auth logic, secrets handling, or runtime configuration changed
- No new dependencies added
- Change is documentation-only and does not alter application behavior
