### PR TITLE
fix: bump serialize-javascript override to 7.0.5 (clears Dependabot alert #90)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "overrides": {
     "mocha": {
-      "serialize-javascript": "7.0.3"
+      "serialize-javascript": "7.0.5"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Bumps the `mocha` transitive override for `serialize-javascript` from `7.0.3` → `7.0.5`
- Clears Dependabot alert #90 (medium severity, vulnerable range `< 7.0.5`)

## Test plan

- [ ] CI passes (no functional changes — override bump only)
- [ ] Confirm Dependabot alert #90 is dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)