### PR TITLE
fix: resolve serialize-javascript to 7.0.5 in lockfile (Dependabot #90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20.18.0 <21"
       }
     },
     "apps/api": {
@@ -9955,9 +9955,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "mocha": {
-      "serialize-javascript": "7.0.5"
-    }
+    "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the initial override bump: the nested `mocha.serialize-javascript` override did not update the resolved version in the lockfile. This PR:

- Changes the override from `mocha.serialize-javascript` to a top-level `serialize-javascript >= 7.0.5`
- Runs `npm update serialize-javascript --package-lock-only` to resolve `7.0.5` in the lockfile
- Fully clears Dependabot alert #90 (medium, serialize-javascript < 7.0.5)

## Test plan

- [ ] CI passes (lockfile-only change — no runtime behavior change)
- [ ] Dependabot alert #90 dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)